### PR TITLE
add analogReadResolution(10) for esp32

### DIFF
--- a/components/volume_sensor/volume_sensor.cpp
+++ b/components/volume_sensor/volume_sensor.cpp
@@ -13,6 +13,15 @@ float VolumeSensor::map_value_float(float x, float in_min, float in_max,
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
+void VolumeSensor::setup() {
+  #if defined(ESP32)
+    // Set attenuation to 0db to be as close to esp8266 as possible
+    analogSetPinAttenuation(this->pin_, ADC_0db);
+    // Set ADC resolution to 10 bits (0-1023) on ESP32
+    analogReadResolution(10);
+  #endif
+}
+
 void VolumeSensor::dump_config() {
   LOG_SENSOR("", "Volume Sensor", this);
   ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
@@ -34,10 +43,6 @@ void VolumeSensor::dump_config() {
 }
 
 void VolumeSensor::update() {
-  // Set ADC resolution to 10 bits (0-1023) on ESP32
-  #if defined(ESP32)
-    analogReadResolution(10);
-  #endif
   uint16_t signal_max = 0;
   uint16_t signal_min = 1023;
   unsigned long start_time = millis();

--- a/components/volume_sensor/volume_sensor.cpp
+++ b/components/volume_sensor/volume_sensor.cpp
@@ -34,6 +34,10 @@ void VolumeSensor::dump_config() {
 }
 
 void VolumeSensor::update() {
+  // Set ADC resolution to 10 bits (0-1023) on ESP32
+  #if defined(ESP32)
+    analogReadResolution(10);
+  #endif
   uint16_t signal_max = 0;
   uint16_t signal_min = 1023;
   unsigned long start_time = millis();

--- a/components/volume_sensor/volume_sensor.h
+++ b/components/volume_sensor/volume_sensor.h
@@ -19,6 +19,7 @@ public:
   void set_percentage_sensor(sensor::Sensor *sensor) { this->percentage_sensor_ = sensor; }
 
   void update() override;
+  void setup() override;
   void dump_config() override;
 
 protected:


### PR DESCRIPTION
This configures adc read resolution on esp32 to be 10bit instead of 12 bit.